### PR TITLE
Allow YT links in [youtube]

### DIFF
--- a/lib/post.php
+++ b/lib/post.php
@@ -101,7 +101,7 @@ function postfilter($msg) {
 
 	$msg = preg_replace("'>>([0-9]+)'si", '>><a href=thread.php?pid=\\1#\\1>\\1</a>', $msg);
 
-	$msg = preg_replace("'\[youtube\]([\-0-9_a-zA-Z]*?)\[/youtube\]'si", '<iframe width="427" height="240" src="https://www.youtube.com/embed/\\1" frameborder="0" allowfullscreen></iframe>', $msg);
+	$msg = preg_replace("'\[youtube\]((https?\:\/\/)?(www\.)?(youtube\.com|youtu\.?be)\/(watch\?v=)?)?([\-0-9_a-zA-Z]*?)\[\/youtube\]'si", '<iframe width="427" height="240" src="https://www.youtube.com/embed/\\6" frameborder="0" allowfullscreen></iframe>', $msg);
 
 	return $msg;
 }


### PR DESCRIPTION
https://regexr.com/6v1gs
_(Regexr for whatever reason gives an error on first load. But it works fine and adding/removing a character makes it function again. It's also in global mode to test multiple stuff, but it obviously works in singleline.)_

The regex code is long, but it should allow for a variety of formats:
```
[youtube]https://www.youtube.com/watch?v=CzTCqW89Pxs[/youtube]
[youtube]http://youtube.com/watch?v=CzTCqW89Pxs[/youtube]
[youtube]youtu.be/CzTCqW89Pxs[/youtube]
[youtube]CzTCqW89Pxs[/youtube]
```
Also consider allowing [yt] as well.